### PR TITLE
Updates to the "waiting" example

### DIFF
--- a/element/navigating/README.md
+++ b/element/navigating/README.md
@@ -11,11 +11,11 @@ files:
 # Navigating
 
 ```typescript
-import { step } from "@flood/element";
+import { step } from '@flood/element'
 
 export default () => {
   step('Homepage', async browser => {
-    await browser.visit('wordpress.loadtest.io')
+    await browser.visit('https://wordpress.loadtest.io')
     await browser.takeScreenshot()
   })
 }

--- a/element/navigating/README.md
+++ b/element/navigating/README.md
@@ -21,4 +21,4 @@ export default () => {
 }
 ```
 
-In this example instruct the browser to navigate to our Wordpress example site.
+In this example we instruct the browser to navigate to our Wordpress example site and take a screenshot.

--- a/element/waiting/README.md
+++ b/element/waiting/README.md
@@ -1,0 +1,31 @@
+---
+example: Waiting
+stream:
+  name: Waiting Test
+  browser_density: 40
+  duration: 18
+files:
+  - ./example.ts
+---
+
+# Waiting example
+
+## How to use
+
+### Using `element`
+
+Clone this repo locally, and execute [`element` CLI][Element] to run the example on your local machine:
+
+```bash
+npx @flood/element-cli run ./element/waiting/example.ts --no-headless
+```
+
+### Using [Flood](https://flood.io)
+
+Upload [example.ts](./example.ts) to an existing Stream on Flood, or [run it directly on Flood](https://app.flood.io/launch/github/flood-io/load-testing-playground/element/waiting)
+
+## The idea behind the example
+
+This example shows how we can make a step wait for an element to become visible on the page before proceeding. It is important that elements exist on the page before attempting to interact with them. In this example, we navigate to our Wordpress example site, wait for the `.products` element to become visible, and take a screenshot.
+
+[Element]: (https://github.com/flood-io/element)

--- a/element/waiting/example.ts
+++ b/element/waiting/example.ts
@@ -2,7 +2,9 @@ import { step, Until, By } from '@flood/element'
 
 export default () => {
   step('Wait for products', async browser => {
+    await browser.visit('https://wordpress.loadtest.io')
     // Use CSS to find the products list, then wait until it is visible on the page
     await browser.wait(Until.elementIsVisible(By.css('.products')))
+    await browser.takeScreenshot()
   })
 }


### PR DESCRIPTION
- adds README with:
  - front-matter so we can launch the "waiting" example from the site.
  - basic description/instructions that matches the other examples
- expand the waiting example slightly so it visits the page and takes a screenshot
- some small tweaks to the "navigating" example